### PR TITLE
Update general.bib

### DIFF
--- a/docs/source/research/bibliography/general.bib
+++ b/docs/source/research/bibliography/general.bib
@@ -180,15 +180,6 @@ link = {http://www.sciencedirect.com/science/article/pii/0885064X85900147}
   abstract = {We consider approximate methods for calculation of integral of the Wiener process and find the rate of convergence.}
 }
 
-@book{ritter2000average,
-  title={Average-case analysis of numerical problems},
-  author={Ritter, Klaus},
-  number={1733},
-  year={2000},
-  publisher={Springer},
-  series={Lecture Notes in Mathematics}
-}
-
 @article{HenOsbGirRSPA2015,
   author = {Hennig, Philipp and Osborne, Michael A. and Girolami, Mark},
   title = {Probabilistic numerics and uncertainty in computations},
@@ -275,19 +266,6 @@ computations.},
   file = {https://arxiv.org/pdf/1506.04208.pdf}
 }
 
-@ARTICLE{2018arXiv180702582K,
-   author = {{Kanagawa}, M. and {Hennig}, P. and {Sejdinovic}, D. and {Sriperumbudur}, B.~K
-  },
-    title = "{Gaussian Processes and Kernel Methods: A Review on Connections and Equivalences}",
-  journal = {ArXiv e-prints},
-   volume = {1807.02582},
-     year = 2018,
-    month = jul,
-   abstract = {This paper is an attempt to bridge the conceptual gaps between researchers working on the two widely used approaches based on positive definite kernels: Bayesian learning or inference using Gaussian processes on the one side, and frequentist kernel methods based on reproducing kernel Hilbert spaces on the other. It is widely known in machine learning that these two formalisms are closely related; for instance, the estimator of kernel ridge regression is identical to the posterior mean of Gaussian process regression. However, they have been studied and developed almost independently by two essentially separate communities, and this makes it difficult to seamlessly transfer results between them. Our aim is to overcome this potential difficulty. To this end, we review several old and new results and concepts from either side, and juxtapose algorithmic quantities from each framework to highlight close similarities. We also provide discussions on subtle philosophical and theoretical differences between the two approaches.},
-   link = {https://arxiv.org/abs/1807.02582},
-   file = {https://arxiv.org/pdf/1807.02582}
-}
-
 
 @ARTICLE{2019arXiv190104457O,
        author = {{Oates}, C.~J. and {Sullivan}, T.~J.},
@@ -313,4 +291,15 @@ computations.},
         abstract = {It is well understood that Bayesian decision theory and average case analysis are essentially identical. However, if one is interested in performing uncertainty quantification for a numerical task, it can be argued that the decision-theoretic framework is neither appropriate nor sufficient. To this end, we consider an alternative optimality criterion from Bayesian experimental design and study its implied optimal information in the numerical context. This information is demonstrated to differ, in general, from the information that would be used in an average-case-optimal numerical method. The explicit connection to Bayesian experimental design suggests several distinct regimes in which optimal probabilistic numerical methods can be developed.},
         link = {https://arxiv.org/abs/1901.04326},
         file = {https://arxiv.org/pdf/1901.04326.pdf}
+}
+
+@article{teymur2021black,
+        title={Black Box Probabilistic Numerics},
+        author={Teymur, Onur and Foley, Christopher N and Breen, Philip G and Karvonen, Toni and Oates, Chris J},
+        journal = {arXiv e-prints},
+        year={2021},
+        volume = {2106.13718},
+        abstract = {Probabilistic numerics casts numerical tasks, such the numerical solution of differential equations, as inference problems to be solved. One approach is to model the unknown quantity of interest as a random variable, and to constrain this variable using data generated during the course of a traditional numerical method. However, data may be nonlinearly related to the quantity of interest, rendering the proper conditioning of random variables difficult and limiting the range of numerical tasks that can be addressed. Instead, this paper proposes to construct probabilistic numerical methods based only on the final output from a traditional method. A convergent sequence of approximations to the quantity of interest constitute a dataset, from which the limiting quantity of interest can be extrapolated, in a probabilistic analogue of Richardson's deferred approach to the limit. This black box approach (1) massively expands the range of tasks to which probabilistic numerics can be applied, (2) inherits the features and performance of state-of-the-art numerical methods, and (3) enables provably higher orders of convergence to be achieved. Applications are presented for nonlinear ordinary and partial differential equations, as well as for eigenvalue problems-a setting for which no probabilistic numerical methods have yet been developed.},
+        link = {https://arxiv.org/abs/2106.13718},
+        file = {https://arxiv.org/pdf/2106.13718.pdf}
 }


### PR DESCRIPTION
Removed Ritter's average case analysis (not PN, and not historically important in the development of PN) and Kanagawa's review of kernel methods (not specific to PN).  Added Teymur's black-box PN.
